### PR TITLE
Use node to schedule runs of loadreport.

### DIFF
--- a/schedule-loadreport.js
+++ b/schedule-loadreport.js
@@ -5,18 +5,18 @@ var increment = 0;
 function runLoadreport(){
     exec('phantomjs loadreport.js http://www.people.com performance csv', function (error, stdout, stderr) {
         exec('mv reports/loadreport.csv reports/loadreport-' + increment + '.csv', function(error, stdout, stderr){
-        	console.log('CSV done.');
+        	console.log('CSV ' + increment + ' done.');
         });
     });
     exec('phantomjs loadreport.js http://www.people.com performancecache json', function (error, stdout, stderr) {
         exec('mv reports/loadreport.json reports/loadreport-' + increment + '.json', function(error, stdout, stderr){
-        	console.log('JSON done.');
+        	console.log('JSON ' + increment + ' done.');
         });
     });
     exec('phantomjs loadreport.js http://www.people.com filmstrip', function (error, stdout, stderr) {
         exec('mkdir filmstrip/filmstrip-' + increment, function(error, stdout, stderr){
         	exec('mv filmstrip/screenshot*.png filmstrip/filmstrip-' + increment + '/', function(error, stdout, stderr){
-        		console.log('Filmstrip done.')
+        		console.log('Filmstrip ' + increment + ' done.')
         	});
         });
     });


### PR DESCRIPTION
Hey here is a way that you can run, on an hourly basis, three different types of Loadreports: CSV, JSON (cached), and Filmstrip.

$ node schedule-loadreport.js

It's a bit rough, and ultimately you'd want to be able to determine the interval of the reports, if necessary. There may also be a better way to name the files and directories produced (timestamp).

I hope this helps though, even if the entire pull request is not accepted.
