### PR TITLE
add junit xml format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 You can take it for a spin in [this live demo](http://loadreport.wesleyhales.com/report.html).
 
 ## loadreport Examples
-### loadreport will write, to csv or json (filmstrip writes to png):
+### loadreport will write, to csv, json or junit format xml (filmstrip writes to png):
 * ``` phantomjs loadreport.js http://cnn.com performance csv ```
 ![loadreport](https://raw.github.com/wesleyhales/loadreport/master/readme/cnn-loadreport.png)
     


### PR DESCRIPTION
discussion to add a junit xml output option:

usage:
phantomjs loadreport.js http://www.lemonde.fr performance junit

output:
&lt;?xml version="1.0" encoding="UTF-8" ?&gt;
&lt;testsuites&gt;
  &lt;testsuite name="domReadystateLoading" tests="1"&gt;
    &lt;testcase name="domReadystateLoading" time="78"/&gt;
  &lt;/testsuite&gt;
  &lt;testsuite name="domReadystateInteractive" tests="1"&gt;
    &lt;testcase name="domReadystateInteractive" time="0"/&gt;
  &lt;/testsuite&gt;
  &lt;testsuite name="windowOnload" tests="1"&gt;
    &lt;testcase name="windowOnload" time="125"/&gt;
  &lt;/testsuite&gt;
  &lt;testsuite name="elapsedLoadTime" tests="1"&gt;
    &lt;testcase name="elapsedLoadTime" time="128"/&gt;
  &lt;/testsuite&gt;
  &lt;testsuite name="numberOfResources" tests="1"&gt;
    &lt;testcase name="numberOfResources" time="29"/&gt;
  &lt;/testsuite&gt;
  &lt;testsuite name="totalResourcesTime" tests="1"&gt;
    &lt;testcase name="totalResourcesTime" time="1251"/&gt;
  &lt;/testsuite&gt;
  &lt;testsuite name="totalResourcesSize" tests="1"&gt;
    &lt;testcase name="totalResourcesSize" time="1344.237"/&gt;
  &lt;/testsuite&gt;
  &lt;testsuite name="nonReportingResources" tests="1"&gt;
    &lt;testcase name="nonReportingResources" time="0"/&gt;
  &lt;/testsuite&gt;
&lt;/testsuites&gt;

drawbacks:
-use of 'time' attribute of junit for non-time value. exemple: totalResourceSize is not a time value of course...
-bad time unit even for time attribute: totalResourcesSize time=1344.237 and should be /3600

avantages: allow users to follow if performance increase or not across builds history (even if values are bad, you can see performance evolution

sample result in jenkins:
![capture decran 2013-08-23 a 16 09 27](https://f.cloud.github.com/assets/1169286/1016580/b2c080fa-0bfd-11e3-88cf-d0f5ffc10ae3.png)
